### PR TITLE
转账交易时,应该使用付款者的签名,而不是收款者的签名

### DIFF
--- a/第四章/4.2.3 钱包、账户和交易功能.ipynb
+++ b/第四章/4.2.3 钱包、账户和交易功能.ipynb
@@ -447,8 +447,8 @@
     "    recipient=tom.address,\n",
     "    amount=0.3\n",
     ")\n",
-    "sig = tom.sign(str(new_transaction))\n",
-    "new_transaction.set_sign(sig, tom.pubkey)"
+    "sig = alice.sign(str(new_transaction))\n",
+    "new_transaction.set_sign(sig, alice.pubkey)"
    ]
   },
   {

--- a/第四章/4.2.3 钱包、账户和交易功能.ipynb
+++ b/第四章/4.2.3 钱包、账户和交易功能.ipynb
@@ -475,7 +475,7 @@
     "    \n",
     "    # 验证交易签名没问题，生成一个新的区块\n",
     "    print(\"验证交易成功\")\n",
-    "    new_block2 = Block(transactions=[new_transaction], prev_hash=\"\")\n",
+    "    new_block2 = Block(transactions=[new_transaction], prev_hash=genesis_block.hash)\n",
     "    print(\"生成新的区块...\")\n",
     "    w2 = ProofOfWork(new_block2, bob)\n",
     "    block = w2.mine()\n",


### PR DESCRIPTION
转账交易时,应该使用付款者的签名,而不是收款者的签名